### PR TITLE
Removed remaining faction conditions

### DIFF
--- a/UI_Browser.lua
+++ b/UI_Browser.lua
@@ -505,7 +505,7 @@ function mrp:Show( player )
 		if UnitIsUnit("player", "target") then
 			--mrp:RequestForBF( UnitName("player") )
 			mrp:UpdateBrowseFrame( player )
-		elseif UnitIsPlayer("target") and UnitIsFriend("player", "target") then
+		elseif UnitIsPlayer("target") then
 			if msp.char[ mrp:UnitNameWithRealm("target") ].supported == false then
 				mrp:Print( L["%s doesn’t appear to have an addon which supports MSP."], mrp:UnitNameWithRealm("target") )
 			else

--- a/UI_Tooltip.lua
+++ b/UI_Tooltip.lua
@@ -21,12 +21,8 @@ local function mrp_MouseoverEvent( this, event, addon )
 		if UnitIsUnit( "player", "mouseover" ) then
 			mrp:UpdateTooltip( UnitName("player"), "player" )
 		elseif UnitIsPlayer("mouseover") then
-			if UnitIsFriend("player", "mouseover") then
-				msp:Request( mrp:UnitNameWithRealm("mouseover") )
-				mrp:UpdateTooltip( mrp:UnitNameWithRealm("mouseover"), "mouseover" )
-			else
-				mrp:UpdateTooltip( mrp:UnitNameWithRealm("mouseover"), "mouseover" )
-			end
+			msp:Request( mrp:UnitNameWithRealm("mouseover") )
+			mrp:UpdateTooltip( mrp:UnitNameWithRealm("mouseover"), "mouseover" )
 		else
 			mrp.TTShown = nil
 		end


### PR DESCRIPTION
`UnitIsFriend` condition was still used in 2 situations : 

- On mouseover to request someone's profile

- On using /mrp Show without additional arguments to open the target's profile

No additional call to this function are present in the code.