### PR TITLE
Update /mrp Show to not require adding realm name

### DIFF
--- a/Command.lua
+++ b/Command.lua
@@ -118,7 +118,7 @@ mrp.Commands = {
 			local cmd, name = strsplit(" ", strtrim(input), 2)
 			name = strtrim( name )
 			if not(name:match("%-")) then
-				name = (name .. "-" .. string.gsub(GetRealmName(), " ", ""))
+				name = (name .. "-" .. GetRealmName():gsub("[%s*%-*]", ""))
 			end
 			mrp:Print( L["Requesting details from %s."], name )
 			mrp:Show( name )

--- a/Command.lua
+++ b/Command.lua
@@ -117,6 +117,9 @@ mrp.Commands = {
 		elseif para ~= "" then
 			local cmd, name = strsplit(" ", strtrim(input), 2)
 			name = strtrim( name )
+			if not(name:match("%-")) then
+				name = (name .. "-" .. string.gsub(GetRealmName(), " ", ""))
+			end
 			mrp:Print( L["Requesting details from %s."], name )
 			mrp:Show( name )
 		else


### PR DESCRIPTION
/mrp Show was requiring Name-RealmName on every request, including on one's own server. This change allows a return to proper functionality, only requiring a realmname off server.